### PR TITLE
Updated the blinks image aspect ratio to auto

### DIFF
--- a/src/ui/ActionLayout.tsx
+++ b/src/ui/ActionLayout.tsx
@@ -101,7 +101,7 @@ export const ActionLayout = ({
           <Linkable url={websiteUrl} className="block px-5 pt-5">
             <img
               className={clsx('w-full rounded-xl object-cover object-left', {
-                'aspect-square': !form,
+                'aspect-auto': !form,
                 'aspect-[2/1]': form,
               })}
               src={image}


### PR DESCRIPTION
The aspect ratio of the rendered image is always squared which is causing issue for a lot of devs who already have og images on their links for websites which are mostly 16:9 or maybe 4:3 aspect ratio
example here
<img width="887" alt="Screenshot 2024-07-16 at 1 12 35 PM" src="https://github.com/user-attachments/assets/6581e0b4-37e8-429e-940b-8024b20e5d2d">

it is better to give option to render with the aspect ratio which users choose most of them will have either 1:1 or 16:9 ( because this is the default og image ratio for twitter previews )
