### PR TITLE
fix: recheck security state and action, if action prop changed

### DIFF
--- a/src/ui/ActionContainer.tsx
+++ b/src/ui/ActionContainer.tsx
@@ -279,6 +279,17 @@ export const ActionContainer = ({
         : 'blocked',
   });
 
+  // in case, where action or websiteUrl changes, we need to reset the action state
+  useEffect(() => {
+    if (action === initialAction || action.isChained) {
+      return;
+    }
+
+    setAction(initialAction);
+    setActionState(getOverallActionState(initialAction, websiteUrl));
+    dispatch({ type: ExecutionType.RESET });
+  }, [action, initialAction, websiteUrl]);
+
   useEffect(() => {
     callbacks?.onActionMount?.(
       action,


### PR DESCRIPTION
If `action` prop changes without unmount, security state wouldn't update.