### PR TITLE
Add "Content-Type" header on action chaining

### DIFF
--- a/src/api/Action/Action.ts
+++ b/src/api/Action/Action.ts
@@ -214,6 +214,7 @@ export class Action {
       method: 'POST',
       body: JSON.stringify(chainData),
       headers: {
+        'Content-Type': 'application/json',
         Accept: 'application/json',
       },
     });


### PR DESCRIPTION
Problem description: 
When using action chaining, if the user supplies a `NextActionLink` of type `PostNextActionLink`, the subsequent POST request is missing the "Content-Type" header, which makes the request be sent in `text/plain` format even though it is always JSON since we are sending a JSON object which contains the account and signature fields.

Without that header, I had to use a custom parser just for that endpoint to use a text parser instead of JSON parser, and in such cases debugging the cause of the body not being correctly parsed is not that obvious unless you explicitly inspect the request headers in the browser developer console.

I am able to supply screenshots or a recording of reproducing the issue if that is required.