### PR TITLE
replace nanoid with nanoid/non-secure for id generation

### DIFF
--- a/packages/blinks-core/src/api/Action/Action.ts
+++ b/packages/blinks-core/src/api/Action/Action.ts
@@ -1,4 +1,4 @@
-import { nanoid } from 'nanoid';
+import { nanoid } from 'nanoid/non-secure';
 import { proxify, proxifyImage } from '../../utils';
 import { isUrlSameOrigin } from '../../utils/security.ts';
 import type { ActionAdapter } from '../ActionConfig.ts';


### PR DESCRIPTION
`nanoid/non-secure` is still pretty random and is sufficient for action id, but does not require `crypto`