### PR TITLE
Change window.open target

### DIFF
--- a/packages/blinks/src/ui/internal/hooks/useIsolatedLayoutPropNormalizer.ts
+++ b/packages/blinks/src/ui/internal/hooks/useIsolatedLayoutPropNormalizer.ts
@@ -55,7 +55,7 @@ export const useIsolatedLayoutPropNormalizer = ({
             if (result) {
               window.open(
                 extra.data.externalLink,
-                '_blank',
+                '_self',
                 'norefferer,noopener',
               );
               return extra.onNext();

--- a/packages/blinks/src/ui/internal/hooks/useLayoutPropNormalizer.tsx
+++ b/packages/blinks/src/ui/internal/hooks/useLayoutPropNormalizer.tsx
@@ -85,7 +85,7 @@ export const useLayoutPropNormalizer = ({
           if (result) {
             window.open(
               extra.data.externalLink,
-              '_blank',
+              '_self',
               'norefferer,noopener',
             );
             return extra.onNext();


### PR DESCRIPTION
Changed the `target` property of the `window.open` function from `_blank` to `_self`. 
This is used in the context of actions of type `external-link`, which are supposed to open a new tab when the action button is clicked.

With the current behaviour, for different browsers and browser configurations it might open a new browser window instead of a new tab. I assume this is not the intended behaviour, since the confirm popup which gets shown says that the link will open in a new tab of the browser. The `_self` target value ensures that the current browsing context is always used.

`target` property reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#target