### PR TITLE
"@dialectlabs/blinks-core" missing in package.json

### DIFF
--- a/examples/mini-blinks/package.json
+++ b/examples/mini-blinks/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@dialectlabs/blinks": "^0.13.1",
+    "@dialectlabs/blinks-core": "^0.13.1",
     "@solana/wallet-adapter-react": "^0.15.0",
     "@solana/wallet-adapter-react-ui": "^0.9.0",
     "@solana/web3.js": "^1.95.1",


### PR DESCRIPTION
Since "@dialectlabs/blinks" is exporting functions of "@dialectlabs/blinks-core", we need to add "@dialectlabs/blinks-core" in package.json.

I had the following issue:
![Image 09-10-24 at 10 21 PM](https://github.com/user-attachments/assets/73459c6a-a230-444f-b2d0-ad265c8a35ff)

which I fixed by manually fixed by running `bun i @dialectlabs/blinks-core`