### PR TITLE
Feature/adjust exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm add @dialectlabs/blinks viem wagmi
 
 #### Style Presets
 
-`Blink` component contains a `stylePreset` prop that accepts the following values:
+`BlinkComponent` component contains a `stylePreset` prop that accepts the following values:
 
 - `default` - [dial.to](https://dial.to)-styled blink (light)
 - `x-dark` - [X](https://x.com/)-styled blink (dark)
@@ -29,9 +29,9 @@ npm add @dialectlabs/blinks viem wagmi
 
 ```tsx
 import '@dialectlabs/blinks/index.css';
-import { Blink } from "@dialectlabs/blinks";
+import { BlinkComponent } from "@dialectlabs/blinks";
 
-<Blink stylePreset="x-dark" ... />
+<BlinkComponent stylePreset="x-dark" ... />
 ```
 
 #### Overriding Theme

--- a/packages/blinks/src/ext/twitter.tsx
+++ b/packages/blinks/src/ext/twitter.tsx
@@ -16,7 +16,7 @@ import {
   type SecurityLevel,
 } from '@dialectlabs/blinks-core';
 import { createRoot } from 'react-dom/client';
-import { Blink, type StylePreset } from '../ui';
+import { BlinkComponent, type StylePreset } from '../ui';
 
 type ObserverSecurityLevel = SecurityLevel;
 
@@ -245,7 +245,7 @@ function createBlink({
 
   blinkRoot.render(
     <div onClick={(e) => e.stopPropagation()}>
-      <Blink
+      <BlinkComponent
         adapter={config}
         stylePreset={resolveXStylePreset()}
         blink={blink}

--- a/packages/blinks/src/ui/ActionsOnlyBlink.tsx
+++ b/packages/blinks/src/ui/ActionsOnlyBlink.tsx
@@ -3,7 +3,7 @@ import {
   BlinkContainer,
 } from '@dialectlabs/blinks-core';
 import { useCallback } from 'react';
-import type { BlinkProps } from './Blink.tsx';
+import type { BlinkProps } from './BlinkComponent.tsx';
 import { useBaseLayoutPropNormalizer } from './hooks';
 import { ActionsOnlyBlinkLayout } from './layouts/ActionsOnlyBlinkLayout.tsx';
 import type { StylePreset } from './types.ts';

--- a/packages/blinks/src/ui/BlinkComponent.tsx
+++ b/packages/blinks/src/ui/BlinkComponent.tsx
@@ -14,7 +14,7 @@ export interface BlinkProps
   stylePreset?: StylePreset;
 }
 
-export const Blink = ({
+export const BlinkComponent = ({
   _Layout: Layout = NormalizedBaseBlinkLayout,
   stylePreset,
   ...props
@@ -42,3 +42,6 @@ export const NormalizedBaseBlinkLayout = (
 
   return <BaseBlinkLayout {...normalizedProps} />;
 };
+
+// backwards compatibility
+export { BlinkComponent as Blink };

--- a/packages/blinks/src/ui/index.ts
+++ b/packages/blinks/src/ui/index.ts
@@ -1,5 +1,5 @@
 export * from './ActionsOnlyBlink.tsx';
-export * from './Blink.tsx';
+export * from './BlinkComponent.tsx';
 export * from './hooks';
 export * from './layouts';
 export * from './Miniblink.tsx';


### PR DESCRIPTION
* separate useAction and useBlink exports from the core package
  * useBlink uses the api, where useAction is the old version. Both return `BlinkInstance`
* Rename Blink component to BlinkComponent (backwards compatible)