### PR TITLE
chore: transaction confirmation error handling

### DIFF
--- a/packages/blinks-core/src/solana/BlinkSolanaConfig.ts
+++ b/packages/blinks-core/src/solana/BlinkSolanaConfig.ts
@@ -75,6 +75,12 @@ export class BlinkSolanaConfig implements BlinkAdapter {
             '[@dialectlabs/blinks-core] Error confirming transaction',
             e,
           );
+          rej(
+            new Error(
+              'Error confirming transaction. Please check your RPC connection and transaction status',
+            ),
+          );
+          return;
         }
 
         setTimeout(confirm, 3000);


### PR DESCRIPTION
Exit loop on unexpected error during transaction confirmation to prevent unnecessary wait and misleading timeout messages