### PR TITLE
chore: fixed broken link to register a blink

### DIFF
--- a/packages/blinks/src/ui/layouts/BaseBlinkLayout.tsx
+++ b/packages/blinks/src/ui/layouts/BaseBlinkLayout.tsx
@@ -243,7 +243,7 @@ export const BaseBlinkLayout = ({
                 </span>
               )}
               <a
-                href="https://docs.dialect.to/documentation/actions/security"
+                href="https://docs.dialect.to/blinks/blinks-provider/blink-registry"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="blink-security-badge mb-0.5 flex items-center"


### PR DESCRIPTION
Replaced a broken link to our blink registration section in our docs.